### PR TITLE
Enforce max-len in situations where prettier cannot

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,10 @@ module.exports = {
       aspects: ['noHref', 'invalidHref', 'preferButton'],
     }],
 
+    // enforce line len in situations where prettier cannot (should have same value as printWidth)
+    // see https://github.com/prettier/eslint-config-prettier#max-len
+    'max-len': [2, 100],
+
     'prettier/prettier': [2, {
       printWidth: 100,
       semi: false,

--- a/test/fixtures/variables.js
+++ b/test/fixtures/variables.js
@@ -11,3 +11,7 @@ const unusedA = 1
 export const functionB = a => {
   return a
 }
+
+// exceed line length where prettier cannot fix
+export const long =
+  'Text that exceeds the 100 char limit but is unable to be split by prettier. See https://github.com/prettier/eslint-config-prettier#max-len'

--- a/test/index.js
+++ b/test/index.js
@@ -14,4 +14,4 @@ invalid.title = provided => `correctly lints issues with ${provided}`
 
 test('imports', invalid, 'import', 3)
 test('missing propTypes', invalid, 'prop-types')
-test('variables', invalid, 'variables', 4)
+test('variables', invalid, 'variables', 5)


### PR DESCRIPTION
Sets `max-len` in order to catch situations where prettier is unable to fix (such as long strings, comments, etc).

See https://github.com/prettier/eslint-config-prettier#max-len for more information.