### PR TITLE
Loosen `react/jsx-no-useless-fragment`

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,10 @@ module.exports = {
     // allow function creation in render
     'react/jsx-no-bind': 0,
 
+    // permit useless fragments because they're sometimes necessary for function components to
+    // return `JSX.Element` in TypeScript
+    'react/jsx-no-useless-fragment': 0,
+
     // allow spreading props
     'react/jsx-props-no-spreading': 0,
 


### PR DESCRIPTION
The rule (correctly) errors on this code, but this workaround is necessary in TypeScript because function components must return `JSX.Element | null` to do a fundamental limitation in the current TS compiler.

```tsx
function Foo(): JSX.Element {
  return <>foo</>
}
```

The rule does have [an option to support expressions](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md#allowexpressions) but that requires wrapping all non-elements in variables which seems inconvenient. Useless fragments aren't really a problem so it seems easier to disable the rule.