### PR TITLE
Override `default-param-last` with TypeScript equivalent

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,6 +176,9 @@ module.exports = {
         'react/prop-types': 0,
         'react/react-in-jsx-scope': 0,
 
+        'default-param-last': 0,
+        '@typescript-eslint/default-param-last': 2,
+
         'no-unused-expressions': 0,
         '@typescript-eslint/no-unused-expressions': 2,
 


### PR DESCRIPTION
See [the docs](https://github.com/typescript-eslint/typescript-eslint/blob/84b4a8c5a67bc8da586cb00589fd56737a261885/packages/eslint-plugin/docs/rules/default-param-last.md). This permits optional parameters after parameters with defaults, e.g.:

```ts
function(foo: number, bar = 1, baz?: number) {}
```