### PR TITLE
Permit unused rest siblings

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -64,6 +64,13 @@ exports[`lints all fixtures: functionComponent.tsx 1`] = `
     "rule": "import/no-extraneous-dependencies",
     "severity": 2,
   },
+  {
+    "column": 16,
+    "line": 11,
+    "message": "'unused' is assigned a value but never used.",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "severity": 1,
+  },
 ]
 `;
 

--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -7,7 +7,7 @@ exports[`lints all fixtures: class.tsx 1`] = `
     "line": 1,
     "message": "'Foo' is defined but never used.",
     "rule": "@typescript-eslint/no-unused-vars",
-    "severity": 1,
+    "severity": 2,
   },
 ]
 `;
@@ -43,14 +43,14 @@ exports[`lints all fixtures: experimental.tsx 1`] = `
     "line": 4,
     "message": "'nullishCoalescing' is assigned a value but never used.",
     "rule": "@typescript-eslint/no-unused-vars",
-    "severity": 1,
+    "severity": 2,
   },
   {
     "column": 7,
     "line": 5,
     "message": "'optionalChaining' is assigned a value but never used.",
     "rule": "@typescript-eslint/no-unused-vars",
-    "severity": 1,
+    "severity": 2,
   },
 ]
 `;
@@ -63,13 +63,6 @@ exports[`lints all fixtures: functionComponent.tsx 1`] = `
     "message": "'react' should be listed in the project's dependencies, not devDependencies.",
     "rule": "import/no-extraneous-dependencies",
     "severity": 2,
-  },
-  {
-    "column": 16,
-    "line": 11,
-    "message": "'unused' is assigned a value but never used.",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "severity": 1,
   },
 ]
 `;
@@ -130,28 +123,28 @@ exports[`lints all fixtures: jsdoc.ts 1`] = `
     "line": 10,
     "message": "'add' is defined but never used.",
     "rule": "@typescript-eslint/no-unused-vars",
-    "severity": 1,
+    "severity": 2,
   },
   {
     "column": 10,
     "line": 17,
     "message": "'subtract' is defined but never used.",
     "rule": "@typescript-eslint/no-unused-vars",
-    "severity": 1,
+    "severity": 2,
   },
   {
     "column": 10,
     "line": 21,
     "message": "'multiply' is defined but never used.",
     "rule": "@typescript-eslint/no-unused-vars",
-    "severity": 1,
+    "severity": 2,
   },
   {
     "column": 10,
     "line": 26,
     "message": "'divide' is defined but never used.",
     "rule": "@typescript-eslint/no-unused-vars",
-    "severity": 1,
+    "severity": 2,
   },
 ]
 `;
@@ -250,7 +243,7 @@ exports[`lints all fixtures: variables.ts 1`] = `
     "line": 3,
     "message": "'unusedA' is assigned a value but never used.",
     "rule": "@typescript-eslint/no-unused-vars",
-    "severity": 1,
+    "severity": 2,
   },
   {
     "column": 26,
@@ -271,7 +264,7 @@ exports[`lints all fixtures: variables.ts 1`] = `
     "line": 10,
     "message": "'c' is defined but never used.",
     "rule": "@typescript-eslint/no-unused-vars",
-    "severity": 1,
+    "severity": 2,
   },
   {
     "column": 14,

--- a/fixtures/functionComponent.tsx
+++ b/fixtures/functionComponent.tsx
@@ -4,14 +4,15 @@ const ThemeContext = createContext({color: 'red'})
 
 interface ButtonProps {
   text: string
+  unused: number
 }
 
 export default function Button(props: ButtonProps): JSX.Element {
-  const {text} = props
+  const {text, unused, ...rest} = props
   const theme = useContext(ThemeContext)
   const [count, setCount] = useState(1)
   return (
-    <div style={{color: theme.color}}>
+    <div style={{color: theme.color}} {...rest}>
       <button type="button" onClick={() => setCount((prevCount) => prevCount + 1)}>
         {text}
       </button>

--- a/index.js
+++ b/index.js
@@ -220,6 +220,9 @@ module.exports = {
         // allow noop functions
         '@typescript-eslint/no-empty-function': 0,
 
+        // disallow unused variables
+        '@typescript-eslint/no-unused-vars': [2, {ignoreRestSiblings: true}],
+
         // prevent types from being redundantly specified in JSDoc comments
         'jsdoc/no-types': 2,
       },


### PR DESCRIPTION
This allows for the following pattern of omitting certain properties from an object:

```ts
const {foo, ...rest} = obj
doSomething(rest)
```