### PR TITLE
Permit `for...of` statements

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -194,6 +194,18 @@ exports[`lints all fixtures: prop-types.tsx 1`] = `
 ]
 `;
 
+exports[`lints all fixtures: syntax.tsx 1`] = `
+[
+  {
+    "column": 1,
+    "line": 1,
+    "message": "Prefer default export on a file with single export.",
+    "rule": "import/prefer-default-export",
+    "severity": 2,
+  },
+]
+`;
+
 exports[`lints all fixtures: ts-exports.ts 1`] = `[]`;
 
 exports[`lints all fixtures: variables.js 1`] = `

--- a/fixtures/syntax.tsx
+++ b/fixtures/syntax.tsx
@@ -1,0 +1,5 @@
+export function forEach<T>(array: T[], callback: (item: T) => void): void {
+  for (const item of array) {
+    callback(item)
+  }
+}

--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ module.exports = {
     // https://github.com/prettier/eslint-config-prettier#arrow-body-style-and-prefer-arrow-callback
     'arrow-body-style': [2, 'as-needed', {requireReturnForObjectLiteral: false}],
 
+    // disallow uncommon syntax that is hard to use correctly
+    'no-restricted-syntax': [2, 'ForInStatement', 'LabeledStatement', 'WithStatement'],
+
     // ensure that default, named, and namespaced imports have been exported by the target file
     'import/default': 2,
     'import/named': 2,


### PR DESCRIPTION
The AirBnB config's justification for disallowing this syntax is that it requires a generator polyfill, but this is no longer true as we stopped supporting IE 11.