### PR TITLE
Permit files to have a single named export

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -194,17 +194,7 @@ exports[`lints all fixtures: prop-types.tsx 1`] = `
 ]
 `;
 
-exports[`lints all fixtures: syntax.tsx 1`] = `
-[
-  {
-    "column": 1,
-    "line": 1,
-    "message": "Prefer default export on a file with single export.",
-    "rule": "import/prefer-default-export",
-    "severity": 2,
-  },
-]
-`;
+exports[`lints all fixtures: syntax.tsx 1`] = `[]`;
 
 exports[`lints all fixtures: ts-exports.ts 1`] = `[]`;
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ module.exports = {
     'import/named': 2,
     'import/namespace': [2, {allowComputed: true}],
 
+    // allow files with a single named export
+    'import/prefer-default-export': 0,
+
     // allow extensionless imports of TS files
     'import/extensions': [
       2,


### PR DESCRIPTION
In practice, this is one of our most frequently-disabled rules because it prevents files that will eventually have multiple exports (e.g., `utils.ts`, `env.ts`) from being structured that way when there is initially only a single export.