### PR TITLE
Disable `import/no-unresolved` in TypeScript

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -102,13 +102,6 @@ exports[`lints all fixtures: import.ts 1`] = `
     "rule": "import/extensions",
     "severity": 2,
   },
-  {
-    "column": 27,
-    "line": 2,
-    "message": "Unable to resolve path to module './nonexistent'.",
-    "rule": "import/no-unresolved",
-    "severity": 2,
-  },
 ]
 `;
 

--- a/index.js
+++ b/index.js
@@ -179,6 +179,7 @@ module.exports = {
         'import/export': 0,
         'import/named': 0,
         'import/namespace': 0,
+        'import/no-unresolved': 0,
         'react/forbid-prop-types': 0,
         'react/jsx-no-undef': 0,
         'react/no-unused-prop-types': 0,


### PR DESCRIPTION
This is checked by the TypeScript compiler.