### PR TITLE
Remove dependency on Airbnb config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 [![Build Status](https://img.shields.io/github/actions/workflow/status/kensho-technologies/eslint-config/ci.yml?branch=main)](https://github.com/kensho-technologies/eslint-config/actions)
 [![npm](https://img.shields.io/npm/v/@kensho-technologies/eslint-config.svg)](https://npm.im/@kensho-technologies/eslint-config)
 
-This [ESLint config](http://eslint.org/docs/developer-guide/shareable-configs) extends [Airbnb's config](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb) (based on their [style guide](https://github.com/airbnb/javascript)) to work with TypeScript.
-
-Since the upstream config is well-maintained and justified, we try to stick as close to it as possible. All divergences are [annotated](index.js), and tend towards increased ES2020 support, Prettier adoption, and TypeScript compatibility, rather than stylistic preferences.
-
 ## Install
 
 ```sh

--- a/index.js
+++ b/index.js
@@ -1,12 +1,18 @@
+const confusingBrowserGlobals = require('confusing-browser-globals')
+
 module.exports = {
-  extends: ['airbnb', 'airbnb/hooks', 'plugin:import/typescript', 'prettier'],
-  plugins: ['jsdoc'],
+  extends: ['eslint:recommended', 'plugin:import/typescript', 'prettier'],
+  plugins: ['import', 'react', 'jsx-a11y', 'react-hooks', 'jsdoc'],
   parserOptions: {
-    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
   },
   env: {
-    // allow browser globals
     browser: true,
+    es2024: true,
+    node: true,
   },
   rules: {
     // https://github.com/prettier/eslint-config-prettier#arrow-body-style-and-prefer-arrow-callback
@@ -16,12 +22,9 @@ module.exports = {
     'no-restricted-syntax': [2, 'ForInStatement', 'LabeledStatement', 'WithStatement'],
 
     // ensure that default, named, and namespaced imports have been exported by the target file
-    'import/default': 2,
-    'import/named': 2,
+    'import/default': [2],
+    'import/named': [2],
     'import/namespace': [2, {allowComputed: true}],
-
-    // allow files with a single named export
-    'import/prefer-default-export': 0,
 
     // allow extensionless imports of TS files
     'import/extensions': [
@@ -58,48 +61,22 @@ module.exports = {
     'import/order': [2, {'newlines-between': 'always'}],
 
     // require well-formatted JSDoc comments, when they exist
-    'jsdoc/check-alignment': 2,
-    'jsdoc/check-indentation': 2,
-    'jsdoc/check-param-names': 2,
+    'jsdoc/check-alignment': [2],
+    'jsdoc/check-indentation': [2],
+    'jsdoc/check-param-names': [2],
     'jsdoc/check-tag-names': [2, {definedTags: ['jest-environment']}],
     'jsdoc/require-hyphen-before-param-description': [2, 'never'],
-    'jsdoc/require-description': 2,
-    'jsdoc/require-param-description': 2,
-    'jsdoc/require-param-name': 2,
-    'jsdoc/require-returns-description': 2,
+    'jsdoc/require-description': [2],
+    'jsdoc/require-param-description': [2],
+    'jsdoc/require-param-name': [2],
+    'jsdoc/require-returns-description': [2],
     'jsdoc/tag-lines': [2, 'never', {startLines: 1}],
 
     // allow non-ID-linked <label>s to accomodate those containing linked <input>s
-    'jsx-a11y/label-has-for': 0,
     'jsx-a11y/label-has-associated-control': [2, {assert: 'either'}],
-
-    // allow event listeners on static elements (e.g. onClick on divs)
-    'jsx-a11y/no-static-element-interactions': 0,
 
     // https://github.com/prettier/eslint-config-prettier#arrow-body-style-and-prefer-arrow-callback
     'prefer-arrow-callback': [2, {allowNamedFunctions: false, allowUnboundThis: true}],
-
-    // disallow .jsx files for consistency
-    'react/jsx-filename-extension': 0,
-
-    // allow function creation in render
-    'react/jsx-no-bind': 0,
-
-    // permit useless fragments because they're sometimes necessary for function components to
-    // return `JSX.Element` in TypeScript
-    'react/jsx-no-useless-fragment': 0,
-
-    // allow spreading props
-    'react/jsx-props-no-spreading': 0,
-
-    // the modern JSX runtime does not require React to be in scope
-    'react/react-in-jsx-scope': 0,
-
-    // do not enforce a particular style of component definition
-    'react/function-component-definition': 0,
-
-    // do not require default props for optional props
-    'react/require-default-props': 0,
 
     'react/sort-comp': [
       2,
@@ -143,16 +120,460 @@ module.exports = {
       },
     ],
 
-    // permit both styles of state declaration
-    'react/state-in-constructor': 0,
-
     // require statics to be declared as public fields
     'react/static-property-placement': [2, 'static public field'],
+
+    // follow rules of hooks
+    'react-hooks/rules-of-hooks': [2],
+    'react-hooks/exhaustive-deps': [2],
+
+    // everything below is ported from eslint-config-airbnb
+    'jsx-a11y/alt-text': [
+      'error',
+      {
+        elements: ['img', 'object', 'area', 'input[type="image"]'],
+        img: [],
+        object: [],
+        area: [],
+        'input[type="image"]': [],
+      },
+    ],
+    'jsx-a11y/anchor-has-content': ['error', {components: []}],
+    'jsx-a11y/anchor-is-valid': [
+      'error',
+      {
+        components: ['Link'],
+        specialLink: ['to'],
+        aspects: ['noHref', 'invalidHref', 'preferButton'],
+      },
+    ],
+    'jsx-a11y/aria-activedescendant-has-tabindex': ['error'],
+    'jsx-a11y/aria-props': ['error'],
+    'jsx-a11y/aria-proptypes': ['error'],
+    'jsx-a11y/aria-role': ['error', {ignoreNonDOM: false}],
+    'jsx-a11y/aria-unsupported-elements': ['error'],
+    'jsx-a11y/click-events-have-key-events': ['error'],
+    'jsx-a11y/control-has-associated-label': [
+      'error',
+      {
+        labelAttributes: ['label'],
+        controlComponents: [],
+        ignoreElements: ['audio', 'canvas', 'embed', 'input', 'textarea', 'tr', 'video'],
+        ignoreRoles: [
+          'grid',
+          'listbox',
+          'menu',
+          'menubar',
+          'radiogroup',
+          'row',
+          'tablist',
+          'toolbar',
+          'tree',
+          'treegrid',
+        ],
+        depth: 5,
+      },
+    ],
+    'jsx-a11y/heading-has-content': ['error', {components: ['']}],
+    'jsx-a11y/html-has-lang': ['error'],
+    'jsx-a11y/iframe-has-title': ['error'],
+    'jsx-a11y/img-redundant-alt': ['error'],
+    'jsx-a11y/interactive-supports-focus': ['error'],
+    'jsx-a11y/lang': ['error'],
+    'jsx-a11y/media-has-caption': ['error', {audio: [], video: [], track: []}],
+    'jsx-a11y/mouse-events-have-key-events': ['error'],
+    'jsx-a11y/no-access-key': ['error'],
+    'jsx-a11y/no-autofocus': ['error', {ignoreNonDOM: true}],
+    'jsx-a11y/no-distracting-elements': ['error', {elements: ['marquee', 'blink']}],
+    'jsx-a11y/no-interactive-element-to-noninteractive-role': [
+      'error',
+      {tr: ['none', 'presentation']},
+    ],
+    'jsx-a11y/no-noninteractive-element-interactions': [
+      'error',
+      {handlers: ['onClick', 'onMouseDown', 'onMouseUp', 'onKeyPress', 'onKeyDown', 'onKeyUp']},
+    ],
+    'jsx-a11y/no-noninteractive-element-to-interactive-role': [
+      'error',
+      {
+        ul: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid'],
+        ol: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid'],
+        li: ['menuitem', 'option', 'row', 'tab', 'treeitem'],
+        table: ['grid'],
+        td: ['gridcell'],
+      },
+    ],
+    'jsx-a11y/no-noninteractive-tabindex': ['error', {tags: [], roles: ['tabpanel']}],
+    'jsx-a11y/no-redundant-roles': ['error'],
+    'jsx-a11y/role-has-required-aria-props': ['error'],
+    'jsx-a11y/role-supports-aria-props': ['error'],
+    'jsx-a11y/scope': ['error'],
+    'jsx-a11y/tabindex-no-positive': ['error'],
+    'no-underscore-dangle': [
+      'error',
+      {
+        allow: ['__REDUX_DEVTOOLS_EXTENSION_COMPOSE__'],
+        allowAfterThis: false,
+        allowAfterSuper: false,
+        enforceInMethodNames: true,
+        allowAfterThisConstructor: false,
+        allowFunctionParams: true,
+        enforceInClassFields: false,
+        allowInArrayDestructuring: true,
+        allowInObjectDestructuring: true,
+      },
+    ],
+    'class-methods-use-this': [
+      'error',
+      {
+        exceptMethods: [
+          'render',
+          'getInitialState',
+          'getDefaultProps',
+          'getChildContext',
+          'componentWillMount',
+          'UNSAFE_componentWillMount',
+          'componentDidMount',
+          'componentWillReceiveProps',
+          'UNSAFE_componentWillReceiveProps',
+          'shouldComponentUpdate',
+          'componentWillUpdate',
+          'UNSAFE_componentWillUpdate',
+          'componentDidUpdate',
+          'componentWillUnmount',
+          'componentDidCatch',
+          'getSnapshotBeforeUpdate',
+        ],
+        enforceForClassFields: true,
+      },
+    ],
+    'react/forbid-prop-types': [
+      'error',
+      {
+        forbid: ['any', 'array', 'object'],
+        checkContextTypes: true,
+        checkChildContextTypes: true,
+      },
+    ],
+    'react/jsx-boolean-value': ['error', 'never', {always: []}],
+    'react/jsx-no-duplicate-props': ['error', {ignoreCase: true}],
+    'react/jsx-no-undef': ['error'],
+    'react/jsx-pascal-case': ['error', {allowAllCaps: true, ignore: []}],
+    'react/jsx-uses-react': ['error'],
+    'react/jsx-uses-vars': ['error'],
+    'react/no-danger': ['warn'],
+    'react/no-deprecated': ['error'],
+    'react/no-did-update-set-state': ['error'],
+    'react/no-will-update-set-state': ['error'],
+    'react/no-is-mounted': ['error'],
+    'react/no-string-refs': ['error'],
+    'react/no-unknown-property': ['error'],
+    'react/prefer-es6-class': ['error', 'always'],
+    'react/prefer-stateless-function': ['error', {ignorePureComponents: true}],
+    'react/prop-types': ['error', {ignore: [], customValidators: [], skipUndeclared: false}],
+    'react/require-render-return': ['error'],
+    'react/self-closing-comp': ['error'],
+    'react/jsx-no-target-blank': [
+      'error',
+      {enforceDynamicLinks: 'always', links: true, forms: false},
+    ],
+    'react/jsx-no-comment-textnodes': ['error'],
+    'react/no-render-return-value': ['error'],
+    'react/no-find-dom-node': ['error'],
+    'react/no-danger-with-children': ['error'],
+    'react/no-unused-prop-types': ['error', {customValidators: [], skipShapeProps: true}],
+    'react/style-prop-object': ['error'],
+    'react/no-unescaped-entities': ['error'],
+    'react/no-children-prop': ['error'],
+    'react/no-array-index-key': ['error'],
+    'react/forbid-foreign-prop-types': ['warn', {allowInPropTypes: true}],
+    'react/void-dom-elements-no-children': ['error'],
+    'react/default-props-match-prop-types': ['error', {allowRequiredDefaults: false}],
+    'react/no-redundant-should-component-update': ['error'],
+    'react/no-unused-state': ['error'],
+    'react/no-typos': ['error'],
+    'react/jsx-curly-brace-presence': ['error', {props: 'never', children: 'never'}],
+    'react/destructuring-assignment': ['error', 'always'],
+    'react/no-access-state-in-setstate': ['error'],
+    'react/button-has-type': ['error', {button: true, submit: true, reset: false}],
+    'react/no-this-in-sfc': ['error'],
+    'react/jsx-fragments': ['error', 'syntax'],
+    'react/jsx-no-script-url': ['error', [{name: 'Link', props: ['to']}]],
+    'react/jsx-no-constructed-context-values': ['error'],
+    'react/no-unstable-nested-components': ['error'],
+    'react/no-namespace': ['error'],
+    'react/prefer-exact-props': ['error'],
+    'react/no-arrow-function-lifecycle': ['error'],
+    'react/no-invalid-html-attribute': ['error'],
+    'react/no-unused-class-component-methods': ['error'],
+    strict: ['error', 'never'],
+    'import/no-unresolved': [
+      'error',
+      {
+        commonjs: true,
+        caseSensitive: true,
+        caseSensitiveStrict: false,
+      },
+    ],
+    'import/export': ['error'],
+    'import/no-named-as-default': ['error'],
+    'import/no-named-as-default-member': ['error'],
+    'import/no-mutable-exports': ['error'],
+    'import/no-amd': ['error'],
+    'import/first': ['error'],
+    'import/no-duplicates': ['error'],
+    'import/newline-after-import': ['error'],
+    'import/no-absolute-path': ['error'],
+    'import/no-dynamic-require': ['error'],
+    'import/no-webpack-loader-syntax': ['error'],
+    'import/no-named-default': ['error'],
+    'import/no-self-import': ['error'],
+    'import/no-cycle': [
+      'error',
+      {
+        maxDepth: '∞',
+        ignoreExternal: false,
+        allowUnsafeDynamicCyclicDependency: false,
+      },
+    ],
+    'import/no-useless-path-segments': ['error', {commonjs: true}],
+    'import/no-import-module-exports': ['error', {exceptions: []}],
+    'import/no-relative-packages': ['error'],
+    'no-restricted-exports': ['error', {restrictedNamedExports: ['default', 'then']}],
+    'no-useless-computed-key': ['error'],
+    'no-useless-constructor': ['error'],
+    'no-useless-rename': [
+      'error',
+      {ignoreDestructuring: false, ignoreImport: false, ignoreExport: false},
+    ],
+    'no-var': ['error'],
+    'object-shorthand': ['error', 'always', {ignoreConstructors: false, avoidQuotes: true}],
+    'prefer-const': ['error', {destructuring: 'any', ignoreReadBeforeAssign: true}],
+    'prefer-destructuring': [
+      'error',
+      {
+        VariableDeclarator: {array: false, object: true},
+        AssignmentExpression: {array: true, object: false},
+      },
+      {enforceForRenamedProperties: false},
+    ],
+    'prefer-numeric-literals': ['error'],
+    'prefer-rest-params': ['error'],
+    'prefer-spread': ['error'],
+    'prefer-template': ['error'],
+    'symbol-description': ['error'],
+    'no-label-var': ['error'],
+    'no-restricted-globals': [
+      'error',
+      {name: 'isFinite', message: 'Use Number.isFinite instead.'},
+      {name: 'isNaN', message: 'Use Number.isNaN instead.'},
+    ].concat(confusingBrowserGlobals),
+    'no-shadow': ['error'],
+    'no-undef-init': ['error'],
+    'no-unused-vars': ['error', {vars: 'all', args: 'after-used', ignoreRestSiblings: true}],
+    'no-use-before-define': ['error', {functions: true, classes: true, variables: true}],
+    camelcase: [
+      'error',
+      {properties: 'never', ignoreDestructuring: false, ignoreImports: false, ignoreGlobals: false},
+    ],
+    'func-names': ['warn'],
+    'lines-between-class-members': ['error', 'always', {exceptAfterSingleLine: false}],
+    'lines-around-directive': ['error', {before: 'always', after: 'always'}],
+    'new-cap': [
+      'error',
+      {
+        newIsCap: true,
+        newIsCapExceptions: [],
+        capIsNew: false,
+        capIsNewExceptions: ['Immutable.Map', 'Immutable.Set', 'Immutable.List'],
+        properties: true,
+      },
+    ],
+    'no-array-constructor': ['error'],
+    'no-bitwise': ['error'],
+    'no-continue': ['error'],
+    'no-lonely-if': ['error'],
+    'no-multi-assign': ['error'],
+    'no-nested-ternary': ['error'],
+    'no-new-object': ['error'],
+    'no-plusplus': ['error'],
+    'no-unneeded-ternary': ['error', {defaultAssignment: false}],
+    'one-var': ['error', 'never'],
+    'operator-assignment': ['error', 'always'],
+    'prefer-exponentiation-operator': ['error'],
+    'prefer-object-spread': ['error'],
+    'spaced-comment': [
+      'error',
+      'always',
+      {
+        line: {exceptions: ['-', '+'], markers: ['=', '!', '/']},
+        block: {exceptions: ['-', '+'], markers: ['=', '!', ':', '::'], balanced: true},
+      },
+    ],
+    'unicode-bom': ['error', 'never'],
+    'global-require': ['error'],
+    'no-buffer-constructor': ['error'],
+    'no-new-require': ['error'],
+    'no-path-concat': ['error'],
+    'no-await-in-loop': ['error'],
+    'no-console': ['warn'],
+    'no-promise-executor-return': ['error'],
+    'no-template-curly-in-string': ['error'],
+    'no-unreachable-loop': ['error', {ignore: []}],
+    'valid-typeof': ['error', {requireStringLiterals: true}],
+    'array-callback-return': [
+      'error',
+      {allowImplicit: true, checkForEach: false, allowVoid: false},
+    ],
+    'block-scoped-var': ['error'],
+    'consistent-return': ['error'],
+    'default-case': ['error', {commentPattern: '^no default$'}],
+    'default-case-last': ['error'],
+    'default-param-last': ['error'],
+    'dot-notation': ['error', {allowKeywords: true, allowPattern: ''}],
+    eqeqeq: ['error', 'always', {null: 'ignore'}],
+    'grouped-accessor-pairs': ['error'],
+    'guard-for-in': ['error'],
+    'max-classes-per-file': ['error', 1],
+    'no-alert': ['warn'],
+    'no-caller': ['error'],
+    'no-constructor-return': ['error'],
+    'no-else-return': ['error', {allowElseIf: false}],
+    'no-empty-function': ['error', {allow: ['arrowFunctions', 'functions', 'methods']}],
+    'no-eval': ['error'],
+    'no-extend-native': ['error'],
+    'no-extra-bind': ['error'],
+    'no-extra-label': ['error'],
+    'no-implied-eval': ['error'],
+    'no-iterator': ['error'],
+    'no-labels': ['error', {allowLoop: false, allowSwitch: false}],
+    'no-lone-blocks': ['error'],
+    'no-loop-func': ['error'],
+    'no-multi-str': ['error'],
+    'no-new': ['error'],
+    'no-new-func': ['error'],
+    'no-new-wrappers': ['error'],
+    'no-octal-escape': ['error'],
+    'no-param-reassign': [
+      'error',
+      {
+        props: true,
+        ignorePropertyModificationsFor: [
+          'acc',
+          'accumulator',
+          'e',
+          'ctx',
+          'context',
+          'req',
+          'request',
+          'res',
+          'response',
+          '$scope',
+          'staticContext',
+        ],
+      },
+    ],
+    'no-proto': ['error'],
+    'no-restricted-properties': [
+      'error',
+      {
+        object: 'arguments',
+        property: 'callee',
+        message: 'arguments.callee is deprecated',
+      },
+      {
+        object: 'global',
+        property: 'isFinite',
+        message: 'Please use Number.isFinite instead',
+      },
+      {
+        object: 'self',
+        property: 'isFinite',
+        message: 'Please use Number.isFinite instead',
+      },
+      {
+        object: 'window',
+        property: 'isFinite',
+        message: 'Please use Number.isFinite instead',
+      },
+      {
+        object: 'global',
+        property: 'isNaN',
+        message: 'Please use Number.isNaN instead',
+      },
+      {
+        object: 'self',
+        property: 'isNaN',
+        message: 'Please use Number.isNaN instead',
+      },
+      {
+        object: 'window',
+        property: 'isNaN',
+        message: 'Please use Number.isNaN instead',
+      },
+      {
+        property: '__defineGetter__',
+        message: 'Please use Object.defineProperty instead.',
+      },
+      {
+        property: '__defineSetter__',
+        message: 'Please use Object.defineProperty instead.',
+      },
+      {
+        object: 'Math',
+        property: 'pow',
+        message: 'Use the exponentiation operator (**) instead.',
+      },
+    ],
+    'no-return-assign': ['error', 'always'],
+    'no-return-await': ['error'],
+    'no-script-url': ['error'],
+    'no-self-compare': ['error'],
+    'no-sequences': ['error'],
+    'no-throw-literal': ['error'],
+    'no-unused-expressions': [
+      'error',
+      {
+        allowShortCircuit: false,
+        allowTernary: false,
+        allowTaggedTemplates: false,
+        enforceForJSX: false,
+      },
+    ],
+    'no-useless-concat': ['error'],
+    'no-useless-return': ['error'],
+    'no-void': ['error'],
+    'prefer-promise-reject-errors': ['error', {allowEmptyReject: true}],
+    'prefer-regex-literals': ['error', {disallowRedundantWrapping: true}],
+    radix: ['error'],
+    'vars-on-top': ['error'],
+    yoda: ['error'],
   },
+
   settings: {
     // do not attempt to parse npm modules or non-JS files for exports
     'import/ignore': ['node_modules', '.(png|svg|jpg|css|pdf)$'],
+
+    'import/extensions': ['.ts', '.cts', '.mts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'],
+    'import/external-module-folders': ['node_modules', 'node_modules/@types'],
+    'import/parsers': {
+      '@typescript-eslint/parser': ['.ts', '.cts', '.mts', '.tsx'],
+    },
+    'import/resolver': {
+      node: {
+        extensions: ['.ts', '.cts', '.mts', '.tsx', '.js', '.jsx'],
+      },
+    },
+
+    react: {
+      pragma: null,
+      version: 'detect',
+      defaultVersion: '18',
+    },
+
+    propWrapperFunctions: ['forbidExtraProps', 'exact', 'Object.freeze'],
   },
+
   overrides: [
     {
       files: ['*.ts', '*.tsx'],
@@ -179,7 +600,6 @@ module.exports = {
         'react/jsx-no-undef': 0,
         'react/no-unused-prop-types': 0,
         'react/prop-types': 0,
-        'react/react-in-jsx-scope': 0,
         'react/no-unknown-property': 0,
 
         'default-param-last': 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "28.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "eslint-config-airbnb": "^19.0.4",
+        "confusing-browser-globals": "^1.0.11",
         "eslint-config-prettier": "^9.1.0"
       },
       "devDependencies": {
@@ -2063,6 +2063,7 @@
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -2347,6 +2348,7 @@
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -2364,6 +2366,7 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -2484,6 +2487,7 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-intrinsic": "^1.2.4"
       },
@@ -2496,6 +2500,7 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2559,6 +2564,7 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
       "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -2713,46 +2719,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-config-airbnb": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
-      "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
-      "license": "MIT",
-      "dependencies": {
-        "eslint-config-airbnb-base": "^15.0.0",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.5"
-      },
-      "engines": {
-        "node": "^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.32.0 || ^8.2.0",
-        "eslint-plugin-import": "^2.25.3",
-        "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-react": "^7.28.0",
-        "eslint-plugin-react-hooks": "^4.3.0"
-      }
-    },
-    "node_modules/eslint-config-airbnb-base": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
-      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
-      "license": "MIT",
-      "dependencies": {
-        "confusing-browser-globals": "^1.0.10",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.5",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.32.0 || ^8.2.0",
-        "eslint-plugin-import": "^2.25.2"
       }
     },
     "node_modules/eslint-config-prettier": {
@@ -3516,6 +3482,7 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
@@ -3656,6 +3623,7 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -3694,6 +3662,7 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -3706,6 +3675,7 @@
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3718,6 +3688,7 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4568,6 +4539,7 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4577,6 +4549,7 @@
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
       "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "define-properties": "^1.2.1",
@@ -4595,6 +4568,7 @@
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
       "integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -5237,6 +5211,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -5246,6 +5221,7 @@
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-react-hooks": "^4.6.2"
   },
   "dependencies": {
-    "eslint-config-airbnb": "^19.0.4",
+    "confusing-browser-globals": "^1.0.11",
     "eslint-config-prettier": "^9.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
A first step towards refreshing our config. This inlines all of the rules that we were using from `eslint-config-airbnb` and removes the dependency. The result is a bit of a mess, but it's non-disruptive (doesn't enable any rules that were previously disabled) and now it's much clearer which rules are enabled. We can work on paring things down from here.