### PR TITLE
Require Node >=20.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
       - run: npm ci
       - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,8 @@
         "vitest": "^2.0.2"
       },
       "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=9.0.0"
+        "node": ">=20.9.0",
+        "npm": ">=10.0.0"
       },
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=18.12.0",
-    "npm": ">=9.0.0"
+    "node": ">=20.9.0",
+    "npm": ">=10.0.0"
   },
   "main": "index.js",
   "author": "Kensho Technologies, LLC.",


### PR DESCRIPTION
Removes support for Node 18 now that there are no internal uses.